### PR TITLE
Add teacher admin mode to restrict participant removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ __pycache__
 
 # Env files
 .env
+
+# Local teacher credentials for admin mode
+src/teachers.json

--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Teacher admin mode for removing participants
 
 ## Getting Started
 
@@ -31,6 +32,17 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                       | Authenticate teacher/admin mode                                    |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove a participant (teacher credentials required)             |
+
+## Teacher Login (Admin Mode)
+
+Use the user button in the top-right corner of the web UI to login as a teacher.
+
+Example in-memory teacher credentials:
+
+- `mr.johnson` / `teach123`
+- `ms.carter` / `learn456`
 
 ## Data Model
 

--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Students can sign up for activities
 - Teacher admin mode for removing participants
 
 ## Getting Started
@@ -31,18 +31,32 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
-| POST   | `/auth/login`                                                       | Authenticate teacher/admin mode                                    |
-| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove a participant (teacher credentials required)             |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Student self-signup for an activity                                 |
+| POST   | `/auth/login`                                                    | Authenticate teacher/admin mode and receive a short-lived token     |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove a participant (teacher token required)                  |
 
 ## Teacher Login (Admin Mode)
 
 Use the user button in the top-right corner of the web UI to login as a teacher.
 
-Example in-memory teacher credentials:
+Teacher credentials are loaded from JSON in this order:
 
-- `mr.johnson` / `teach123`
-- `ms.carter` / `learn456`
+- `src/teachers.json` (local, ignored by git)
+- `src/teachers.example.json` (fallback template)
+
+Each user entry contains a `username` and SHA-256 `password_hash`.
+
+To generate a hash for a password:
+
+```bash
+python -c "import hashlib; print(hashlib.sha256('your-password'.encode()).hexdigest())"
+```
+
+After login, use the returned token for privileged requests:
+
+- Header: `X-Teacher-Token: <token>`
+
+The signup endpoint remains open for student self-registration.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -9,6 +9,10 @@ from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
+import json
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
 import os
 from pathlib import Path
 
@@ -78,16 +82,64 @@ activities = {
     }
 }
 
-# In-memory teacher credentials for admin actions.
-teachers = {
-    "mr.johnson": "teach123",
-    "ms.carter": "learn456"
-}
+# Session duration for teacher admin mode.
+SESSION_DURATION_MINUTES = 60
+
+
+def _load_teacher_password_hashes() -> dict[str, str]:
+    """Load teacher credential hashes from JSON configuration."""
+    base_dir = Path(__file__).parent
+    teachers_file = base_dir / "teachers.json"
+    fallback_file = base_dir / "teachers.example.json"
+    source_file = teachers_file if teachers_file.exists() else fallback_file
+
+    with source_file.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    users = data.get("users", [])
+    return {
+        entry["username"]: entry["password_hash"]
+        for entry in users
+        if "username" in entry and "password_hash" in entry
+    }
+
+
+teacher_password_hashes = _load_teacher_password_hashes()
+
+# In-memory token store for short-lived teacher sessions.
+teacher_sessions: dict[str, dict[str, str | datetime]] = {}
 
 
 class LoginRequest(BaseModel):
     username: str
     password: str
+
+
+def _create_session_token(username: str) -> str:
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=SESSION_DURATION_MINUTES)
+    teacher_sessions[token] = {
+        "username": username,
+        "expires_at": expires_at,
+    }
+    return token
+
+
+def _get_username_from_token(token: str | None) -> str | None:
+    if token is None:
+        return None
+
+    session = teacher_sessions.get(token)
+    if session is None:
+        return None
+
+    expires_at = session["expires_at"]
+    if isinstance(expires_at, datetime) and expires_at < datetime.now(timezone.utc):
+        teacher_sessions.pop(token, None)
+        return None
+
+    username = session.get("username")
+    return username if isinstance(username, str) else None
 
 
 @app.get("/")
@@ -125,14 +177,20 @@ def signup_for_activity(activity_name: str, email: str):
 @app.post("/auth/login")
 def login(payload: LoginRequest):
     """Validate teacher credentials for admin mode."""
-    expected_password = teachers.get(payload.username)
-    if expected_password is None or expected_password != payload.password:
+    expected_hash = teacher_password_hashes.get(payload.username)
+    provided_hash = hashlib.sha256(payload.password.encode("utf-8")).hexdigest()
+    if expected_hash is None or expected_hash != provided_hash:
         raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    token = _create_session_token(payload.username)
 
     return {
         "message": "Teacher login successful",
         "role": "teacher",
-        "username": payload.username
+        "username": payload.username,
+        "token": token,
+        "token_type": "bearer",
+        "expires_in": SESSION_DURATION_MINUTES * 60,
     }
 
 
@@ -140,21 +198,13 @@ def login(payload: LoginRequest):
 def unregister_from_activity(
     activity_name: str,
     email: str,
-    x_teacher_username: str | None = Header(default=None),
-    x_teacher_password: str | None = Header(default=None)
+    x_teacher_token: str | None = Header(default=None)
 ):
     """Unregister a student from an activity"""
     # Restrict unregister operation to authenticated teachers.
-    if x_teacher_username is None or x_teacher_password is None:
+    if _get_username_from_token(x_teacher_token) is None:
         raise HTTPException(
-            status_code=403,
-            detail="Only logged-in teachers can remove participants"
-        )
-
-    expected_password = teachers.get(x_teacher_username)
-    if expected_password is None or expected_password != x_teacher_password:
-        raise HTTPException(
-            status_code=403,
+            status_code=401,
             detail="Only logged-in teachers can remove participants"
         )
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,9 +5,10 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
 from pathlib import Path
 
@@ -77,6 +78,17 @@ activities = {
     }
 }
 
+# In-memory teacher credentials for admin actions.
+teachers = {
+    "mr.johnson": "teach123",
+    "ms.carter": "learn456"
+}
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
 
 @app.get("/")
 def root():
@@ -110,9 +122,42 @@ def signup_for_activity(activity_name: str, email: str):
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    """Validate teacher credentials for admin mode."""
+    expected_password = teachers.get(payload.username)
+    if expected_password is None or expected_password != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    return {
+        "message": "Teacher login successful",
+        "role": "teacher",
+        "username": payload.username
+    }
+
+
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    x_teacher_username: str | None = Header(default=None),
+    x_teacher_password: str | None = Header(default=None)
+):
     """Unregister a student from an activity"""
+    # Restrict unregister operation to authenticated teachers.
+    if x_teacher_username is None or x_teacher_password is None:
+        raise HTTPException(
+            status_code=403,
+            detail="Only logged-in teachers can remove participants"
+        )
+
+    expected_password = teachers.get(x_teacher_username)
+    if expected_password is None or expected_password != x_teacher_password:
+        raise HTTPException(
+            status_code=403,
+            detail="Only logged-in teachers can remove participants"
+        )
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,44 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const authToggleButton = document.getElementById("auth-toggle");
+  const authStatus = document.getElementById("auth-status");
+  const authModal = document.getElementById("auth-modal");
+  const authForm = document.getElementById("auth-form");
+  const authCancelButton = document.getElementById("auth-cancel");
+
+  let teacherSession = null;
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateAuthUI() {
+    if (teacherSession) {
+      authStatus.textContent = `Teacher Mode (${teacherSession.username})`;
+      authToggleButton.textContent = "Logout";
+      authToggleButton.setAttribute("aria-label", "Logout teacher");
+    } else {
+      authStatus.textContent = "Student Mode";
+      authToggleButton.textContent = "User";
+      authToggleButton.setAttribute("aria-label", "Open admin login");
+    }
+  }
+
+  function openAuthModal() {
+    authModal.classList.remove("hidden");
+  }
+
+  function closeAuthModal() {
+    authModal.classList.add("hidden");
+    authForm.reset();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +68,14 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li>
+                        <span class="participant-email">${email}</span>
+                        ${
+                          teacherSession
+                            ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">Remove</button>`
+                            : ""
+                        }
+                      </li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +114,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!teacherSession) {
+      showMessage("Only logged-in teachers can remove participants.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,35 +130,79 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "X-Teacher-Username": teacherSession.username,
+            "X-Teacher-Password": teacherSession.password,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
+
+  authToggleButton.addEventListener("click", () => {
+    if (teacherSession) {
+      teacherSession = null;
+      updateAuthUI();
+      fetchActivities();
+      showMessage("Logged out of teacher mode.", "info");
+      return;
+    }
+
+    openAuthModal();
+  });
+
+  authCancelButton.addEventListener("click", () => {
+    closeAuthModal();
+  });
+
+  authForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const username = document.getElementById("teacher-username").value.trim();
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      teacherSession = {
+        username,
+        password,
+      };
+      updateAuthUI();
+      closeAuthModal();
+      fetchActivities();
+      showMessage(`Logged in as ${result.username}.`, "success");
+    } catch (error) {
+      showMessage("Unable to login. Please try again.", "error");
+      console.error("Error during teacher login:", error);
+    }
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
@@ -130,31 +224,21 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
   // Initialize app
+  updateAuthUI();
   fetchActivities();
 });

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -10,14 +10,21 @@ document.addEventListener("DOMContentLoaded", () => {
   const authCancelButton = document.getElementById("auth-cancel");
 
   let teacherSession = null;
+  let messageHideTimeoutId = null;
 
   function showMessage(text, type) {
+    if (messageHideTimeoutId !== null) {
+      clearTimeout(messageHideTimeoutId);
+      messageHideTimeoutId = null;
+    }
+
     messageDiv.textContent = text;
     messageDiv.className = type;
     messageDiv.classList.remove("hidden");
 
-    setTimeout(() => {
+    messageHideTimeoutId = setTimeout(() => {
       messageDiv.classList.add("hidden");
+      messageHideTimeoutId = null;
     }, 5000);
   }
 
@@ -50,6 +57,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML =
+        '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -131,8 +140,7 @@ document.addEventListener("DOMContentLoaded", () => {
         {
           method: "DELETE",
           headers: {
-            "X-Teacher-Username": teacherSession.username,
-            "X-Teacher-Password": teacherSession.password,
+            "X-Teacher-Token": teacherSession.token,
           },
         }
       );
@@ -192,7 +200,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       teacherSession = {
         username,
-        password,
+        token: result.token,
       };
       updateAuthUI();
       closeAuthModal();

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,18 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-content">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="admin-controls">
+          <span id="auth-status" class="auth-status">Student Mode</span>
+          <button id="auth-toggle" class="auth-toggle" type="button" aria-label="Open admin login">
+            User
+          </button>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -44,6 +54,26 @@
     <footer>
       <p>&copy; 2023 Mergington High School</p>
     </footer>
+
+    <div id="auth-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="auth-modal-title">
+      <div class="modal-content">
+        <h3 id="auth-modal-title">Teacher Login</h3>
+        <form id="auth-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button id="auth-cancel" type="button" class="secondary-btn">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,48 @@ body {
 }
 
 header {
-  text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  padding: 0 20px;
+}
+
+.header-content h1,
+.header-content h2 {
+  text-align: left;
+}
+
+.admin-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.auth-status {
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.auth-toggle {
+  background-color: #ffffff;
+  color: #1a237e;
+  border: 1px solid #c5cae9;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 14px;
+}
+
+.auth-toggle:hover {
+  background-color: #e8eaf6;
 }
 
 header h1 {
@@ -192,9 +228,53 @@ button:hover {
   display: none;
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #fff;
+  border-radius: 8px;
+  width: min(420px, 100%);
+  padding: 20px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.secondary-btn {
+  background-color: #eceff1;
+  color: #263238;
+}
+
+.secondary-btn:hover {
+  background-color: #cfd8dc;
+}
+
 footer {
   text-align: center;
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+@media (max-width: 700px) {
+  .header-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/src/teachers.example.json
+++ b/src/teachers.example.json
@@ -1,0 +1,12 @@
+{
+  "users": [
+    {
+      "username": "teacher1",
+      "password_hash": "f9b0078b5df596d2ea19010c001bbd009e651de2c57ca4f0ddcd1f3f65ce3d0c"
+    },
+    {
+      "username": "teacher2",
+      "password_hash": "c52f1f0f82f070e8f6674f3628ff4d19d642f13a6efec0f7c3f543e9cb4605bc"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a top-right user control with teacher login/logout flow
- add backend login endpoint for teacher credential validation
- restrict participant removal so only authenticated teachers can unregister students
- update UI and docs for admin mode behavior

## Why
Students were able to remove each other from activities. This change makes unregister an admin-only action.

## Testing
- validated updated files for editor/runtime errors
- manually verified login state changes and protected unregister flow

Closes #5